### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/demo1.py
+++ b/demo1.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Outdated style string formatting
-print "This is an old-style string formatting %s" % "Test"
+print "This is an old-style string formatting {0!s}".format("Test")
 
 # Replacement fields not explicitly numbered
 print "{} is {}".format("life", "hard")


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:vikramshinde12:quantifiedcode-demo?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:vikramshinde12:quantifiedcode-demo?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)